### PR TITLE
docs(examples): add an usage example to share dedicated host with 2 AWS accounts

### DIFF
--- a/examples/share_to_other_accounts/main.tf
+++ b/examples/share_to_other_accounts/main.tf
@@ -1,0 +1,8 @@
+module "ram" {
+  source = "Xat59/ram/aws"
+
+  resource_share_name = "share-dedicated-host-01"
+
+  principals = ["XXXXXXXXXXXX", "YYYYYYYYYYYY"]
+  resources  = ["arn:aws:ec2:eu-west-1:ZZZZZZZZZZZZ:dedicated-host/h-xxxxxxxxxxxxx"]
+}


### PR DESCRIPTION
Example usage showing how to use this module to share a dedicated host with 2 AWS accounts.